### PR TITLE
Compare objects like arrays

### DIFF
--- a/src/TreeWalker.php
+++ b/src/TreeWalker.php
@@ -171,6 +171,8 @@ class TreeWalker
 
                     if (gettype($assocarray[$key]) == "array") {
                         $this->structPathArray($assocarray[$key], $array, $path);
+                    } elseif (gettype($assocarray[$key]) == "object") {
+                        $this->structPathArray((arrary)$assocarray[$key], $array, $path);
                     } else {
                         if ($path != "") {
                             //Lógica 1


### PR DESCRIPTION
Identical objects were identified as edited items although they were of the same class and had the same properties. They are converted to arrays now before doing the diff.
